### PR TITLE
Fix import naming

### DIFF
--- a/plugins/modules/foreman_architecture.py
+++ b/plugins/modules/foreman_architecture.py
@@ -83,7 +83,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 class ForemanArchitectureModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_auth_source_ldap.py
+++ b/plugins/modules/foreman_auth_source_ldap.py
@@ -160,7 +160,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule
 
 
 class ForemanAuthSourceLdapModule(ForemanTaxonomicEntityAnsibleModule):

--- a/plugins/modules/foreman_bookmark.py
+++ b/plugins/modules/foreman_bookmark.py
@@ -91,7 +91,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 class ForemanBookmarkModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_compute_attribute.py
+++ b/plugins/modules/foreman_compute_attribute.py
@@ -83,7 +83,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 class ForemanComputeAttributeModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_compute_profile.py
+++ b/plugins/modules/foreman_compute_profile.py
@@ -141,7 +141,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 compute_attribute_foreman_spec = {

--- a/plugins/modules/foreman_compute_resource.py
+++ b/plugins/modules/foreman_compute_resource.py
@@ -285,7 +285,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule
 
 
 def get_provider_info(provider):

--- a/plugins/modules/foreman_config_group.py
+++ b/plugins/modules/foreman_config_group.py
@@ -64,7 +64,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 class ForemanConfigGroupModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_domain.py
+++ b/plugins/modules/foreman_domain.py
@@ -78,7 +78,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule, NestedParametersMixin
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule, NestedParametersMixin
 
 
 class ForemanDomainModule(NestedParametersMixin, ForemanTaxonomicEntityAnsibleModule):

--- a/plugins/modules/foreman_environment.py
+++ b/plugins/modules/foreman_environment.py
@@ -60,7 +60,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import (
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import (
     ForemanTaxonomicEntityAnsibleModule,
 )
 

--- a/plugins/modules/foreman_external_usergroup.py
+++ b/plugins/modules/foreman_external_usergroup.py
@@ -63,7 +63,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 class ForemanExternalUsergroupModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_global_parameter.py
+++ b/plugins/modules/foreman_global_parameter.py
@@ -101,7 +101,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule, parameter_value_to_str
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule, parameter_value_to_str
 
 
 class ForemanCommonParameterModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_host.py
+++ b/plugins/modules/foreman_host.py
@@ -160,7 +160,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import (
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import (
     ensure_puppetclasses,
     ForemanEntityAnsibleModule,
     HostMixin,

--- a/plugins/modules/foreman_host_power.py
+++ b/plugins/modules/foreman_host_power.py
@@ -98,7 +98,7 @@ power_state:
     sample: "off"
  '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 def main():

--- a/plugins/modules/foreman_hostgroup.py
+++ b/plugins/modules/foreman_hostgroup.py
@@ -134,7 +134,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import (
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import (
     ensure_puppetclasses,
     HostMixin,
     ForemanTaxonomicEntityAnsibleModule,

--- a/plugins/modules/foreman_image.py
+++ b/plugins/modules/foreman_image.py
@@ -84,7 +84,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 class ForemanImageModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_installation_medium.py
+++ b/plugins/modules/foreman_installation_medium.py
@@ -80,7 +80,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule, OS_LIST
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule, OS_LIST
 
 
 class ForemanInstallationMediumModule(ForemanTaxonomicEntityAnsibleModule):

--- a/plugins/modules/foreman_job_template.py
+++ b/plugins/modules/foreman_job_template.py
@@ -285,7 +285,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 import os
-from ansible.module_utils.foreman_helper import (
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import (
     ForemanTaxonomicEntityAnsibleModule,
     parse_template,
     parse_template_from_file,

--- a/plugins/modules/foreman_location.py
+++ b/plugins/modules/foreman_location.py
@@ -96,7 +96,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule, NestedParametersMixin
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule, NestedParametersMixin
 
 
 class ForemanLocationModule(NestedParametersMixin, ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_model.py
+++ b/plugins/modules/foreman_model.py
@@ -70,7 +70,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 class ForemanModelModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_operatingsystem.py
+++ b/plugins/modules/foreman_operatingsystem.py
@@ -155,7 +155,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import (
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import (
     ForemanEntityAnsibleModule,
     NestedParametersMixin,
     OS_LIST,

--- a/plugins/modules/foreman_organization.py
+++ b/plugins/modules/foreman_organization.py
@@ -67,7 +67,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule, NestedParametersMixin
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule, NestedParametersMixin
 
 
 class ForemanOrganizationModule(NestedParametersMixin, ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_os_default_template.py
+++ b/plugins/modules/foreman_os_default_template.py
@@ -76,7 +76,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 class ForemanOsDefaultTemplateModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_provisioning_template.py
+++ b/plugins/modules/foreman_provisioning_template.py
@@ -222,7 +222,7 @@ RETURN = ''' # '''
 
 import os
 
-from ansible.module_utils.foreman_helper import (
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import (
     ForemanTaxonomicEntityAnsibleModule,
     parse_template,
     parse_template_from_file,

--- a/plugins/modules/foreman_ptable.py
+++ b/plugins/modules/foreman_ptable.py
@@ -196,7 +196,7 @@ RETURN = ''' # '''
 
 import os
 
-from ansible.module_utils.foreman_helper import (
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import (
     ForemanTaxonomicEntityAnsibleModule,
     parse_template,
     parse_template_from_file,

--- a/plugins/modules/foreman_realm.py
+++ b/plugins/modules/foreman_realm.py
@@ -71,7 +71,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule
 
 
 class ForemanRealmModule(ForemanTaxonomicEntityAnsibleModule):

--- a/plugins/modules/foreman_role.py
+++ b/plugins/modules/foreman_role.py
@@ -84,7 +84,7 @@ RETURN = ''' # '''
 
 import copy
 
-from ansible.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule
 
 
 filter_foreman_spec = dict(

--- a/plugins/modules/foreman_scap_content.py
+++ b/plugins/modules/foreman_scap_content.py
@@ -92,7 +92,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanScapDataStreamModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanScapDataStreamModule
 
 
 class ForemanScapContentModule(ForemanScapDataStreamModule):

--- a/plugins/modules/foreman_scap_tailoring_file.py
+++ b/plugins/modules/foreman_scap_tailoring_file.py
@@ -92,7 +92,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanScapDataStreamModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanScapDataStreamModule
 
 
 class ForemanTailoringFileModule(ForemanScapDataStreamModule):

--- a/plugins/modules/foreman_scc_account.py
+++ b/plugins/modules/foreman_scc_account.py
@@ -114,7 +114,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 class KatelloSccAccountModule(KatelloEntityAnsibleModule):

--- a/plugins/modules/foreman_scc_product.py
+++ b/plugins/modules/foreman_scc_product.py
@@ -61,7 +61,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import KatelloAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import KatelloAnsibleModule
 
 
 def main():

--- a/plugins/modules/foreman_search_facts.py
+++ b/plugins/modules/foreman_search_facts.py
@@ -130,7 +130,7 @@ resources:
   type: list
 '''
 
-from ansible.module_utils.foreman_helper import ForemanAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanAnsibleModule
 
 
 def main():

--- a/plugins/modules/foreman_setting.py
+++ b/plugins/modules/foreman_setting.py
@@ -72,7 +72,7 @@ foreman_setting:
 '''
 
 
-from ansible.module_utils.foreman_helper import ForemanAnsibleModule, parameter_value_to_str, _foreman_spec_helper
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanAnsibleModule, parameter_value_to_str, _foreman_spec_helper
 
 
 class ForemanSettingModule(ForemanAnsibleModule):

--- a/plugins/modules/foreman_smart_class_parameter.py
+++ b/plugins/modules/foreman_smart_class_parameter.py
@@ -160,7 +160,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule, parameter_value_to_str
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule, parameter_value_to_str
 
 override_value_foreman_spec = dict(
     match=dict(required=True),

--- a/plugins/modules/foreman_snapshot.py
+++ b/plugins/modules/foreman_snapshot.py
@@ -102,7 +102,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 class ForemanSnapshotModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/foreman_subnet.py
+++ b/plugins/modules/foreman_subnet.py
@@ -185,7 +185,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 import traceback
-from ansible.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule, NestedParametersMixin
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanTaxonomicEntityAnsibleModule, NestedParametersMixin
 try:
     import ipaddress
     HAS_IPADDRESS = True

--- a/plugins/modules/foreman_templates_import.py
+++ b/plugins/modules/foreman_templates_import.py
@@ -111,7 +111,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanTaxonomicAnsibleModule, _flatten_entity
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanTaxonomicAnsibleModule, _flatten_entity
 
 
 def main():

--- a/plugins/modules/foreman_user.py
+++ b/plugins/modules/foreman_user.py
@@ -317,7 +317,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import (
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import (
     ForemanTaxonomicEntityAnsibleModule,
 )
 

--- a/plugins/modules/foreman_usergroup.py
+++ b/plugins/modules/foreman_usergroup.py
@@ -88,7 +88,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import ForemanEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import ForemanEntityAnsibleModule
 
 
 class ForemanUsergroupModule(ForemanEntityAnsibleModule):

--- a/plugins/modules/katello_activation_key.py
+++ b/plugins/modules/katello_activation_key.py
@@ -174,7 +174,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 def override_to_boolnone(override):

--- a/plugins/modules/katello_content_credential.py
+++ b/plugins/modules/katello_content_credential.py
@@ -69,7 +69,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 class KatelloContentCredentialModule(KatelloEntityAnsibleModule):

--- a/plugins/modules/katello_content_view.py
+++ b/plugins/modules/katello_content_view.py
@@ -132,7 +132,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 import copy
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 cvc_foreman_spec = {

--- a/plugins/modules/katello_content_view_filter.py
+++ b/plugins/modules/katello_content_view_filter.py
@@ -172,7 +172,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import KatelloAnsibleModule, _foreman_spec_helper
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import KatelloAnsibleModule, _foreman_spec_helper
 
 content_filter_spec = {
     'id': {},

--- a/plugins/modules/katello_content_view_version.py
+++ b/plugins/modules/katello_content_view_version.py
@@ -132,7 +132,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 def promote_content_view_version(module, content_view_version, environments, force, force_yum_metadata_regeneration):

--- a/plugins/modules/katello_host_collection.py
+++ b/plugins/modules/katello_host_collection.py
@@ -67,7 +67,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule  # noqa 501
 
 
 class KatelloHostCollectionModule(KatelloEntityAnsibleModule):

--- a/plugins/modules/katello_lifecycle_environment.py
+++ b/plugins/modules/katello_lifecycle_environment.py
@@ -73,7 +73,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 class KatelloLifecycleEnvironmentModule(KatelloEntityAnsibleModule):

--- a/plugins/modules/katello_manifest.py
+++ b/plugins/modules/katello_manifest.py
@@ -68,7 +68,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 def main():

--- a/plugins/modules/katello_product.py
+++ b/plugins/modules/katello_product.py
@@ -104,7 +104,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 class KatelloProductModule(KatelloEntityAnsibleModule):

--- a/plugins/modules/katello_repository.py
+++ b/plugins/modules/katello_repository.py
@@ -200,7 +200,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 class KatelloRepositoryModule(KatelloEntityAnsibleModule):

--- a/plugins/modules/katello_repository_set.py
+++ b/plugins/modules/katello_repository_set.py
@@ -194,7 +194,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 def get_desired_repos(desired_substitutions, available_repos):

--- a/plugins/modules/katello_sync.py
+++ b/plugins/modules/katello_sync.py
@@ -97,7 +97,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.foreman_helper import KatelloAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import KatelloAnsibleModule
 
 
 def main():

--- a/plugins/modules/katello_sync_plan.py
+++ b/plugins/modules/katello_sync_plan.py
@@ -99,7 +99,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.foreman_helper import KatelloEntityAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import KatelloEntityAnsibleModule
 
 
 class KatelloSyncPlanModule(KatelloEntityAnsibleModule):

--- a/plugins/modules/katello_upload.py
+++ b/plugins/modules/katello_upload.py
@@ -78,7 +78,7 @@ import os
 import traceback
 
 from ansible.module_utils._text import to_bytes
-from ansible.module_utils.foreman_helper import KatelloAnsibleModule
+from ansible_collections.oasis_roles.satellite.plugins.module_utils.foreman_helper import KatelloAnsibleModule
 
 try:
     from debian import debfile


### PR DESCRIPTION
When moving module_utils into a collection, the naming path for Python
imports becomes significantly mangled